### PR TITLE
Expand sdmTMB_cv to also include leave future out cross validation

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -332,9 +332,10 @@ predict.sdmTMB <- function(object, newdata = object$data,
       )
 
     if (!identical(new_data_time, original_time) & isFALSE(pop_pred)) {
-      if (isTRUE(return_tmb_object) || nsim > 0)
+      if (isTRUE(return_tmb_object) || nsim > 0) {
         cli_warn(c("The time elements in `newdata` are not identical to those in the original dataset.",
           "This is normally fine, but may create problems for index standardization."))
+      }
       missing_time <- original_time[!original_time %in% new_data_time]
       fake_nd_list <- list()
       fake_nd <- newdata[1L,,drop=FALSE]

--- a/man/sdmTMB_cv.Rd
+++ b/man/sdmTMB_cv.Rd
@@ -41,15 +41,16 @@ spatial data.}
 single string, e.g. \code{"fold_id"} representing the name of the variable in
 \code{data}. Ignored if \code{lfocv} is TRUE}
 
-\item{lfocv}{Whether to implement "Leave Future Out Cross Validation", where only
-historical data is used to predict future folds. Defaults to FALSE}
+\item{lfocv}{Whether to implement leave-future-out cross validation where
+data are used to predict future folds. \code{time} argument in \code{\link[=sdmTMB]{sdmTMB()}} must
+be specified. See Details section below.}
 
-\item{n_forecast}{Number of time steps to forecast (e.g. time steps
-1, ..., T used to predict T + \code{n_forecast}), defaults to 1. Ignored
-if \code{lfocv} is FALSE.}
+\item{n_forecast}{If \code{lfocv = TRUE}, number of time steps to forecast. Time
+steps 1, ..., T are used to predict T + \code{n_forecast} and the last
+forecasted time step is used for validation. See Details section below.}
 
-\item{n_validate}{Number of time steps to use as the validation / test set. This
-defaults to 5. Ignored if \code{lfocv} is FALSE.}
+\item{n_validate}{If \code{lfocv = TRUE}, number of times to step through the
+LFOCV process. Defaults to 5. See Details section below.}
 
 \item{parallel}{If \code{TRUE} and a \code{\link[future:plan]{future::plan()}} is supplied, will be run in
 parallel.}
@@ -81,6 +82,8 @@ and CV log likelihood.
 Save log likelihoods of k-fold cross-validation for sdmTMB models.
 }
 \details{
+\strong{Parallel processing}
+
 Parallel processing can be used by setting a \code{future::plan()}.
 
 For example:
@@ -89,6 +92,23 @@ For example:
 plan(multisession)
 # now use sdmTMB_cv() ...
 }\if{html}{\out{</div>}}
+
+\strong{Leave-future-out cross validation (LFOCV)}
+
+An example of LFOCV with 9 time steps, \code{n_forecast = 1}, and \code{n_validate = 2}:
+\itemize{
+\item Fit data to time steps 1 to 7, predict and validate step 8.
+\item Fit data to time steps 1 to 8, predict and validate step 9.
+}
+
+An example of LFOCV with 9 time steps, \code{n_forecast = 2}, and \code{n_validate = 3}:
+\itemize{
+\item Fit data to time steps 1 to 5, predict and validate step 7.
+\item Fit data to time steps 1 to 6, predict and validate step 8.
+\item Fit data to time steps 1 to 7, predict and validate step 9.
+}
+
+See example below.
 }
 \examples{
 \dontshow{if (inla_installed()) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
@@ -128,6 +148,23 @@ m_cv3 <- sdmTMB_cv(
   family = tweedie(link = "log"),
   fold_ids = rep(seq(1, 3), nrow(pcod))[seq(1, nrow(pcod))]
 )
+
+# LFOCV:
+m_lfocv <- sdmTMB_cv(
+  present ~ s(year, k = 4),
+  data = pcod,
+  mesh = mesh,
+  lfocv = TRUE,
+  n_forecast = 2,
+  n_validate = 3,
+  family = binomial(),
+  spatiotemporal = "off",
+  time = "year" # must be specified
+)
+
+# See how the LFOCV folds were assigned:
+example_data <- m_lfocv$models[[1]]$data
+table(example_data$cv_fold, example_data$year)
 }
 \dontshow{\}) # examplesIf}
 }

--- a/man/sdmTMB_cv.Rd
+++ b/man/sdmTMB_cv.Rd
@@ -12,6 +12,9 @@ sdmTMB_cv(
   time = NULL,
   k_folds = 8,
   fold_ids = NULL,
+  lfocv = FALSE,
+  n_forecast = 1,
+  n_validate = 5,
   parallel = TRUE,
   use_initial_fit = FALSE,
   spde = deprecated(),
@@ -36,7 +39,17 @@ spatial data.}
 
 \item{fold_ids}{Optional vector containing user fold IDs. Can also be a
 single string, e.g. \code{"fold_id"} representing the name of the variable in
-\code{data}.}
+\code{data}. Ignored if \code{lfocv} is TRUE}
+
+\item{lfocv}{Whether to implement "Leave Future Out Cross Validation", where only
+historical data is used to predict future folds. Defaults to FALSE}
+
+\item{n_forecast}{Number of time steps to forecast (e.g. time steps
+1, ..., T used to predict T + \code{n_forecast}), defaults to 1. Ignored
+if \code{lfocv} is FALSE.}
+
+\item{n_validate}{Number of time steps to use as the validation / test set. This
+defaults to 5. Ignored if \code{lfocv} is FALSE.}
 
 \item{parallel}{If \code{TRUE} and a \code{\link[future:plan]{future::plan()}} is supplied, will be run in
 parallel.}

--- a/man/sdmTMB_cv.Rd
+++ b/man/sdmTMB_cv.Rd
@@ -12,9 +12,9 @@ sdmTMB_cv(
   time = NULL,
   k_folds = 8,
   fold_ids = NULL,
-  lfocv = FALSE,
-  n_forecast = 1,
-  n_validate = 5,
+  lfo = FALSE,
+  lfo_forecast = 1,
+  lfo_validations = 5,
   parallel = TRUE,
   use_initial_fit = FALSE,
   spde = deprecated(),
@@ -39,17 +39,17 @@ spatial data.}
 
 \item{fold_ids}{Optional vector containing user fold IDs. Can also be a
 single string, e.g. \code{"fold_id"} representing the name of the variable in
-\code{data}. Ignored if \code{lfocv} is TRUE}
+\code{data}. Ignored if \code{lfo} is TRUE}
 
-\item{lfocv}{Whether to implement leave-future-out cross validation where
+\item{lfo}{Whether to implement leave-future-out (LFO) cross validation where
 data are used to predict future folds. \code{time} argument in \code{\link[=sdmTMB]{sdmTMB()}} must
 be specified. See Details section below.}
 
-\item{n_forecast}{If \code{lfocv = TRUE}, number of time steps to forecast. Time
-steps 1, ..., T are used to predict T + \code{n_forecast} and the last
+\item{lfo_forecast}{If \code{lfo = TRUE}, number of time steps to forecast. Time
+steps 1, ..., T are used to predict T + \code{lfo_forecast} and the last
 forecasted time step is used for validation. See Details section below.}
 
-\item{n_validate}{If \code{lfocv = TRUE}, number of times to step through the
+\item{lfo_validations}{If \code{lfo = TRUE}, number of times to step through the
 LFOCV process. Defaults to 5. See Details section below.}
 
 \item{parallel}{If \code{TRUE} and a \code{\link[future:plan]{future::plan()}} is supplied, will be run in
@@ -95,13 +95,13 @@ plan(multisession)
 
 \strong{Leave-future-out cross validation (LFOCV)}
 
-An example of LFOCV with 9 time steps, \code{n_forecast = 1}, and \code{n_validate = 2}:
+An example of LFOCV with 9 time steps, \code{lfo_forecast = 1}, and \code{lfo_validations = 2}:
 \itemize{
 \item Fit data to time steps 1 to 7, predict and validate step 8.
 \item Fit data to time steps 1 to 8, predict and validate step 9.
 }
 
-An example of LFOCV with 9 time steps, \code{n_forecast = 2}, and \code{n_validate = 3}:
+An example of LFOCV with 9 time steps, \code{lfo_forecast = 2}, and \code{lfo_validations = 3}:
 \itemize{
 \item Fit data to time steps 1 to 5, predict and validate step 7.
 \item Fit data to time steps 1 to 6, predict and validate step 8.
@@ -154,9 +154,9 @@ m_lfocv <- sdmTMB_cv(
   present ~ s(year, k = 4),
   data = pcod,
   mesh = mesh,
-  lfocv = TRUE,
-  n_forecast = 2,
-  n_validate = 3,
+  lfo = TRUE,
+  lfo_forecast = 2,
+  lfo_validations = 3,
   family = binomial(),
   spatiotemporal = "off",
   time = "year" # must be specified

--- a/tests/testthat/test-cross-validation.R
+++ b/tests/testthat/test-cross-validation.R
@@ -52,19 +52,16 @@ test_that("Leave future out cross validation works", {
   skip_on_ci()
   skip_on_cran()
   skip_if_not_installed("INLA")
-  suppressWarnings(
-    suppressMessages(
-      x <- sdmTMB_cv(
-        present ~ 1,
-        data = pcod_2011,
-        mesh = pcod_mesh_2011,
-        lfocv = TRUE,
-        n_forecast = 1,
-        n_validate = 2,
-        family = binomial(),
-        time = "year"
-      )
-    ))
+  x <- sdmTMB_cv(
+    present ~ 1,
+    data = pcod_2011,
+    mesh = pcod_mesh_2011,
+    lfo = TRUE,
+    lfo_forecast = 1,
+    lfo_validations = 2,
+    family = binomial(),
+    time = "year"
+  )
   expect_equal(class(x$sum_loglik), "numeric")
   expect_equal(x$sum_loglik, sum(x$data$cv_loglik))
   expect_equal(x$sum_loglik, sum(x$fold_loglik))

--- a/tests/testthat/test-cross-validation.R
+++ b/tests/testthat/test-cross-validation.R
@@ -36,6 +36,16 @@ test_that("Basic cross validation works", {
     data = d, mesh = spde, spatial = "off",
     family = sdmTMB::student(df = 9), time = "year", k_folds = 2
   )
+  expect_equal(class(x$models[[1]]), "sdmTMB")
+
+  # Try passing family as a variable -- this is per Issue #127
+  fam <- gaussian(link = "identity")
+  x <- sdmTMB_cv(
+    log_density ~ 0 + depth_scaled + depth_scaled2 + as.factor(year),
+    data = d, mesh = spde, spatial = "off",
+    family = fam, time = "year", k_folds = 2
+  )
+  expect_equal(class(x$models[[1]]), "sdmTMB")
 })
 
 

--- a/tests/testthat/test-cross-validation.R
+++ b/tests/testthat/test-cross-validation.R
@@ -48,36 +48,35 @@ test_that("Basic cross validation works", {
   expect_equal(class(x$models[[1]]), "sdmTMB")
 })
 
-
 test_that("Leave future out cross validation works", {
   skip_on_ci()
   skip_on_cran()
   skip_if_not_installed("INLA")
-  d <- pcod
-  spde <- make_mesh(d, c("X", "Y"), cutoff = 15)
-
-  set.seed(2)
-  # library(future) # for parallel processing
-  # plan(multisession) # for parallel processing
-  x <- sdmTMB_cv(
-    density ~ 0 + depth_scaled + depth_scaled2 + as.factor(year),
-    data = d, mesh = spde,
-    lfocv = TRUE,
-    n_forecast = 1,
-    family = tweedie(link = "log"), time = "year"
-  )
+  suppressWarnings(
+    suppressMessages(
+      x <- sdmTMB_cv(
+        present ~ 1,
+        data = pcod_2011,
+        mesh = pcod_mesh_2011,
+        lfocv = TRUE,
+        n_forecast = 1,
+        n_validate = 2,
+        family = binomial(),
+        time = "year"
+      )
+    ))
   expect_equal(class(x$sum_loglik), "numeric")
   expect_equal(x$sum_loglik, sum(x$data$cv_loglik))
   expect_equal(x$sum_loglik, sum(x$fold_loglik))
   expect_true("data.frame" %in% class(x$data))
-  expect_equal(class(x$models[[1]]), "sdmTMB")
+  expect_true(inherits(x$models[[1]], "sdmTMB"))
 
   # Can see how the folds are assigned with
-  # table(x$models[[1]]$data$cv_fold, x$models[[1]]$data$year)
+  table(x$models[[1]]$data$cv_fold, x$models[[1]]$data$year)
 
-  expect_equal(length(x$models), 5)
-  expect_equal(length(x$fold_elpd), 5)
-  expect_equal(length(x$fold_loglik), 5)
-  expect_equal(length(x$max_gradients), 5)
-  expect_equal(cor(x$data$cv_fold[which(x$data$cv_fold!=1)], x$data$year[which(x$data$cv_fold!=1)]), 1.0)
+  expect_equal(length(x$models), 2)
+  expect_equal(length(x$fold_elpd), 2)
+  expect_equal(length(x$fold_loglik), 2)
+  expect_equal(length(x$max_gradients), 2)
+  expect_equal(cor(x$data$cv_fold[x$data$cv_fold!=1], x$data$year[x$data$cv_fold!=1]), 1.0)
 })

--- a/tests/testthat/test-cross-validation.R
+++ b/tests/testthat/test-cross-validation.R
@@ -77,3 +77,125 @@ test_that("Leave future out cross validation works", {
   expect_equal(length(x$max_gradients), 2)
   expect_equal(cor(x$data$cv_fold[x$data$cv_fold!=1], x$data$year[x$data$cv_fold!=1]), 1.0)
 })
+
+test_that("Cross validation with offsets works", {
+  skip_on_ci()
+  skip_on_cran()
+  skip_if_not_installed("INLA")
+  skip_if_not_installed("future")
+  skip_if_not_installed("future.apply")
+
+  d <- pcod_2011
+  set.seed(1)
+  d$log_effort <- rnorm(nrow(d))
+
+  library(future)
+  future::plan(future::multisession)
+
+  set.seed(1)
+  fit_cv_off1 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    offset = d$log_effort, #<
+    k_folds = 2,
+    parallel = TRUE #<
+  )
+
+  set.seed(1)
+  fit_cv_off2 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    offset = d$log_effort, #<
+    k_folds = 2,
+    parallel = FALSE #<
+  )
+
+  set.seed(1)
+  fit_cv_off3 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    offset = d$log_effort, #<
+    k_folds = 2,
+    use_initial_fit = TRUE, #<
+    parallel = TRUE #<
+  )
+
+  set.seed(1)
+  fit_cv_off4 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    offset = d$log_effort, #<
+    k_folds = 2,
+    use_initial_fit = TRUE, #<
+    parallel = FALSE #<
+  )
+
+  # now without offset
+  set.seed(1)
+  fit_cv_off5 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    k_folds = 2,
+    use_initial_fit = TRUE, #<
+    parallel = TRUE #<
+  )
+
+  set.seed(1)
+  fit_cv_off6 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    k_folds = 2,
+    use_initial_fit = TRUE, #<
+    parallel = FALSE #<
+  )
+
+  set.seed(1)
+  fit_cv_off7 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    k_folds = 2,
+    use_initial_fit = FALSE, #<
+    parallel = FALSE #<
+  )
+
+  set.seed(1)
+  fit_cv_off8 <- sdmTMB_cv(
+    density ~ 1,
+    data = d,
+    mesh = pcod_mesh_2011,
+    family = tweedie(),
+    spatial = "off",
+    k_folds = 2,
+    use_initial_fit = TRUE, #<
+    parallel = FALSE #<
+  )
+
+  expect_equal(fit_cv_off1$models[[1]]$model, fit_cv_off2$models[[1]]$model)
+  expect_equal(fit_cv_off1$models[[1]]$model, fit_cv_off3$models[[1]]$model)
+  expect_equal(fit_cv_off1$models[[1]]$model, fit_cv_off4$models[[1]]$model)
+
+  expect_equal(fit_cv_off5$models[[1]]$model, fit_cv_off6$models[[1]]$model)
+  expect_equal(fit_cv_off5$models[[1]]$model, fit_cv_off7$models[[1]]$model)
+  expect_equal(fit_cv_off5$models[[1]]$model, fit_cv_off8$models[[1]]$model)
+})

--- a/tests/testthat/test-cross-validation.R
+++ b/tests/testthat/test-cross-validation.R
@@ -37,3 +37,37 @@ test_that("Basic cross validation works", {
     family = sdmTMB::student(df = 9), time = "year", k_folds = 2
   )
 })
+
+
+test_that("Leave future out cross validation works", {
+  skip_on_ci()
+  skip_on_cran()
+  skip_if_not_installed("INLA")
+  d <- pcod
+  spde <- make_mesh(d, c("X", "Y"), cutoff = 15)
+
+  set.seed(2)
+  # library(future) # for parallel processing
+  # plan(multisession) # for parallel processing
+  x <- sdmTMB_cv(
+    density ~ 0 + depth_scaled + depth_scaled2 + as.factor(year),
+    data = d, mesh = spde,
+    lfocv = TRUE,
+    n_forecast = 1,
+    family = tweedie(link = "log"), time = "year"
+  )
+  expect_equal(class(x$sum_loglik), "numeric")
+  expect_equal(x$sum_loglik, sum(x$data$cv_loglik))
+  expect_equal(x$sum_loglik, sum(x$fold_loglik))
+  expect_true("data.frame" %in% class(x$data))
+  expect_equal(class(x$models[[1]]), "sdmTMB")
+
+  # Can see how the folds are assigned with
+  # table(x$models[[1]]$data$cv_fold, x$models[[1]]$data$year)
+
+  expect_equal(length(x$models), 5)
+  expect_equal(length(x$fold_elpd), 5)
+  expect_equal(length(x$fold_loglik), 5)
+  expect_equal(length(x$max_gradients), 5)
+  expect_equal(cor(x$data$cv_fold[which(x$data$cv_fold!=1)], x$data$year[which(x$data$cv_fold!=1)]), 1.0)
+})


### PR DESCRIPTION
Specifically: 

- add new args to sdmTMB_cv to allow for varying (1) validation years with n_validate, and (2) forecast duration with n_forecast
- add tests to test-cross-validation.r

Probably should have Julia add this to the forecast vignette?