### PR TITLE
fix(plot_anisotropy*): Returns NULL if no H

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -15,11 +15,14 @@
 #' anisotropy. The ellipses are centered at coordinates of zero in the space of
 #' the X-Y coordinates being modeled. The ellipses show the spatial and/or
 #' spatiotemporal range (distance at which correlation is effectively
-#' independent) in any direction from zero. Uses \pkg{ggplot2}.
+#' independent) in any direction from zero. Uses \pkg{ggplot2}. If anisotropy
+#' was turned off when fitting the model, `NULL` is returned instead of a
+#' {ggplot2} object.
 #'
 #' `plot_anisotropy2()`: A plot of eigenvectors illustrating the estimated
 #' anisotropy. A list of the plotted data is invisibly returned. Uses base
-#' graphics.
+#' graphics. If anisotropy was turned off when fitting the model, `NULL` is
+#' returned instead of a plot object.
 #' @references Code adapted from VAST R package
 #' @importFrom rlang .data
 #' @examplesIf inla_installed() && ggplot2_installed()
@@ -40,6 +43,18 @@
 #' @rdname plot_anisotropy
 plot_anisotropy <- function(object, return_data = FALSE) {
   stopifnot(inherits(object, "sdmTMB"))
+  check_for_H <- any(grepl(
+    pattern = "ln_H_input",
+    x = names(object$sd_report$par.fixed),
+    ignore.case = TRUE
+  ))
+  if (!check_for_H) {
+    cli::cli_inform(c(
+      x = "H was turned off, i.e., sdmTMB::sdmTMB(anisotropy = FALSE), no figure is available.")
+    )
+    # TODO in the future "plot the isotropic covariance" instead of NULL
+    return(NULL)
+  }
   report <- object$tmb_obj$report(object$tmb_obj$env$last.par.best)
   delta <- isTRUE(object$family$delta)
 
@@ -156,6 +171,19 @@ plot_anisotropy <- function(object, return_data = FALSE) {
 #' @rdname plot_anisotropy
 plot_anisotropy2 <- function(object, model = 1) {
   stopifnot(inherits(object, "sdmTMB"))
+  check_for_H <- any(grepl(
+    pattern = "ln_H_input",
+    x = names(object$sd_report$par.fixed),
+    ignore.case = TRUE
+  ))
+  if (!check_for_H) {
+    cli::cli_inform(c(
+      x = "The anisotropy figure is not available because H was turned off,",
+      " i.e., sdmTMB::sdmTMB(anisotropy = FALSE)."
+    ))
+    # TODO in the future "plot the isotropic covariance" instead of NULL
+    return(NULL)
+  }
   report <- object$tmb_obj$report(object$tmb_obj$env$last.par.best)
   if (model == 1) eig <- eigen(report$H)
   if (model == 2) eig <- eigen(report$H2)

--- a/man/plot_anisotropy.Rd
+++ b/man/plot_anisotropy.Rd
@@ -22,11 +22,14 @@ plot_anisotropy2(object, model = 1)
 anisotropy. The ellipses are centered at coordinates of zero in the space of
 the X-Y coordinates being modeled. The ellipses show the spatial and/or
 spatiotemporal range (distance at which correlation is effectively
-independent) in any direction from zero. Uses \pkg{ggplot2}.
+independent) in any direction from zero. Uses \pkg{ggplot2}. If anisotropy
+was turned off when fitting the model, \code{NULL} is returned instead of a
+{ggplot2} object.
 
 \code{plot_anisotropy2()}: A plot of eigenvectors illustrating the estimated
 anisotropy. A list of the plotted data is invisibly returned. Uses base
-graphics.
+graphics. If anisotropy was turned off when fitting the model, \code{NULL} is
+returned instead of a plot object.
 }
 \description{
 Anisotropy is when spatial correlation is directionally dependent. In


### PR DESCRIPTION
* `plot_anisotropy()` and `plot_anisotropy2()` now return NULL
* `cli::cli_inform()` issues the following message ✖ H was turned off, i.e., sdmTMB::sdmTMB(anisotropy = FALSE), no figure is available.
* Updated the documentation for the return statement.

You will more than likely want to reformat the call to `cli::cli_inform()`. I tested it on my Windows system and everything appears to be working and the fix allows my personal workflow to continue when `plot_anisotropy()` is called on a model ran using `sdmTMB::sdmTMB(anisotropy = FALSE)`.

Close #198