### PR TITLE
loosen residual test tolerance slightly

### DIFF
--- a/tests/testthat/test-5-residuals.R
+++ b/tests/testthat/test-5-residuals.R
@@ -251,7 +251,7 @@ test_that("Pearson residuals work", {
   m1 <- glmmTMB::glmmTMB(prop ~ 1, data = dat, family = gaussian())
   r <- residuals(m, type = "pearson")
   r1 <- residuals(m1, type = "pearson")
-  expect_equal(as.numeric(r), as.numeric(r1))
+  expect_equal(as.numeric(r), as.numeric(r1), tolerance = 1e-6)
 
   # gamma
   set.seed(1)


### PR DESCRIPTION
The newest version of `glmmTMB` is about to go to CRAN. We changed the parameterization of the Gaussian dispersion from log(variance) to log(SD), which changes results slightly and made one of your comparisons testing with `glmmTMB` fail (the deviations were only 3e-08 on average, but this is larger than the default `expect_equal()` tolerance of ~ 1.5e-08 ...) This PR loosens the tolerance for that test slightly (to 1e-05; 1e-06 or 1e-07 would probably be sufficient but I don't think it hurts to leave it at 1e-05).  Since this is a tiny change you could always reject the PR and change the tolerance setting however you preferred ...

