### PR TITLE
tidy coefficents for linear smoothers

### DIFF
--- a/R/tidy.R
+++ b/R/tidy.R
@@ -155,6 +155,17 @@ tidy.sdmTMB <- function(x, effects = c("fixed", "ran_pars", "ran_vals"), model =
     )
   }
 
+  if (x$tmb_data$has_smooths) {
+    p <- print_smooth_effects(x)
+    mm <- p$smooth_effects
+    out <- rbind(out,
+                 data.frame(term = rownames(mm),
+                            estimate = mm[,"bs"],
+                            std.error = mm[,"bs_se"],
+                            stringsAsFactors = FALSE))
+  }
+
+
   if (conf.int) {
     out$conf.low <- as.numeric(trans(out$estimate - crit * out$std.error))
     out$conf.high <- as.numeric(trans(out$estimate + crit * out$std.error))

--- a/sdmTMB.Rproj
+++ b/sdmTMB.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 1e54a969-ff39-402d-83f4-c260f1f06bda
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/tests/testthat/test-tidy.R
+++ b/tests/testthat/test-tidy.R
@@ -45,4 +45,14 @@ test_that("tidy works", {
   x <- tidy(fit, "ran_pars", conf.int = TRUE)
   x
   expect_true(sum(is.na(x$std.error)) == 0L)
+
+  # test smooth handling
+  fit <- sdmTMB(
+    density ~ s(depth),
+    data = pcod_2011, mesh = mesh,
+    family = tweedie(link = "log")
+  )
+  x <- tidy(fit)
+  expect_equal(x$term, c("(Intercept)", "sdepth"))
+
 })


### PR DESCRIPTION
Small fix added to tidy(). Includes estimates of smoothers (b and b_se) in tidy() method. They were already in print(). Fixes issue #90 