### PR TITLE
Issue 259: Cross validation with LFOCV

### DIFF
--- a/R/cross-val.R
+++ b/R/cross-val.R
@@ -164,7 +164,7 @@ ll_sdmTMB <- function(object, withheld_y, withheld_mu) {
 #'
 #' m_cv <- sdmTMB_cv(
 #'   density ~ 0 + depth_scaled + depth_scaled2,
-#'   data = pcod, mesh = mesh,
+#'   data = pcod, mesh = mesh, spatial = "off",
 #'   family = tweedie(link = "log"), k_folds = 2
 #' )
 #'

--- a/R/cross-val.R
+++ b/R/cross-val.R
@@ -164,7 +164,7 @@ ll_sdmTMB <- function(object, withheld_y, withheld_mu) {
 #'
 #' m_cv <- sdmTMB_cv(
 #'   density ~ 0 + depth_scaled + depth_scaled2,
-#'   data = pcod, mesh = mesh, spatial = "off",
+#'   data = pcod, mesh = mesh,
 #'   family = tweedie(link = "log"), k_folds = 2
 #' )
 #'
@@ -248,7 +248,7 @@ sdmTMB_cv <- function(
         # fold id increasing order + forecast
         data$cv_fold[data[[time]] == t_validate[t]] <- lfo_validations - t + 1 + lfo_forecast
       }
-      data$cv_fold <- as.numeric(as.factor(data$cv_fold))
+      #data$cv_fold <- as.numeric(as.factor(data$cv_fold))
     } else {
       dd <- lapply(split(data, data[[time]]), function(x) {
         x$cv_fold <- sample(rep(seq(1L, k_folds), nrow(x)), size = nrow(x))

--- a/README.Rmd
+++ b/README.Rmd
@@ -332,14 +332,14 @@ ggplot(p, aes(X, Y, fill = zeta_s_year_scaled)) + geom_raster() +
 
 See the vignette on [Fitting spatial trend models with sdmTMB](https://pbs-assess.github.io/sdmTMB/articles/spatial-trend-models.html) for more details.
 
-### Random intercepts
+### Random intercepts and slopes
 
-We can use the same syntax (`1 | group`) as lme4 or glmmTMB to fit random intercepts:
+We can use the same syntax (`1 | group`) as lme4 or glmmTMB to fit random intercepts and slopes:
 
 ```{r, eval=FALSE, echo=TRUE, warning=FALSE, message=FALSE}
 pcod$year_factor <- as.factor(pcod$year)
 fit <- sdmTMB(
-  density ~ s(depth, k = 5) + (1 | year_factor),
+  density ~ (1 + depth| year_factor),
   data = pcod, mesh = mesh,
   time = "year",
   family = tweedie(link = "log")

--- a/README.md
+++ b/README.md
@@ -504,15 +504,15 @@ See the vignette on [Fitting spatial trend models with
 sdmTMB](https://pbs-assess.github.io/sdmTMB/articles/spatial-trend-models.html)
 for more details.
 
-### Random intercepts
+### Random intercepts and slopes
 
 We can use the same syntax (`1 | group`) as lme4 or glmmTMB to fit
-random intercepts:
+random intercepts and slopes:
 
 ``` r
 pcod$year_factor <- as.factor(pcod$year)
 fit <- sdmTMB(
-  density ~ s(depth, k = 5) + (1 | year_factor),
+  density ~ (1 + depth| year_factor),
   data = pcod, mesh = mesh,
   time = "year",
   family = tweedie(link = "log")

--- a/vignettes/articles/cross-validation.Rmd
+++ b/vignettes/articles/cross-validation.Rmd
@@ -173,12 +173,126 @@ We can ignore the total log-likelihood, and just focus on the first element of l
 m_cv$fold_loglik[[1]]
 ```
 
-<!-- # Leave Future Out Cross-Validation -->
+# Leave Future Out Cross-Validation
+<<<<<<< Updated upstream
 
-<!-- We can do LFOCV using the relevant arguments. Our dataset has 9 time steps. Therefore, if we use the arguments `lfo_forecast=2` and `lfo_validations=3`, the cross validation will: -->
-<!-- - Fit data to time steps 1 to 5, predict and validate step 7. -->
-<!-- - Fit data to time steps 1 to 6, predict and validate step 8. -->
-<!-- - Fit data to time steps 1 to 7, predict and validate step 9. -->
+Next, we can illustrate a special kind of cross-validation for temporally structured data called leave future out cross-validation (LFOCV). With LFOCV, data historical training data are only used to predict the future (e.g. data from time steps 1-8 used to predict time step 9, data from time-steps 1-9 used to predict time step 10, etc). To implement this kind of cross validation, we can turn on `lfo = TRUE`. The two other important parameters to set are how many time steps in the future will be generating predictions for with each fold (`lfo_forecast`, defaults to 1 time step) and how many years at the end of the data should be peeled off and used as test datasets (`lfo_validation`, for this example we'll use 3 time steps).   
+```{r}
+m_lfocv <- sdmTMB_cv(
+  present ~ s(year, k = 3),
+  data = pcod,
+  mesh = mesh,
+  lfo = TRUE, # do LFOCV
+  lfo_forecast = 1, # number of time steps to forecast
+  lfo_validations = 3, # number of time steps to validate
+  family = binomial(),
+  spatiotemporal = "off",
+  time = "year" # must be specified
+)
+```
+
+If we wanted to verify the LFOCV training models, we could inspect them and compare them to manual fits with `sdmTMB`. Using the above example, we could replicate the 2nd model (`m_lfocv$models[[2]]`) with this call:
+
+```{r eval=FALSE}
+yrs <- unique(pcod$year)
+sdmTMB_cv_test <- sdmTMB(
+  present ~ s(year, k = 3),
+  data = pcod,
+  mesh = mesh,
+  weights = ifelse(pcod$year < yrs[length(yrs)-1], 1, 0),
+  family = binomial(),
+  spatiotemporal = "off",
+  time = "year" 
+)
+```
+
+The `weights` argument is used here so that we can use the identical mesh to the full dataset, but specify which points contribute to the likelihood (1) or not (0).
+
+As a more complicated example, we can demonstrate making predictions 2 timesteps ahead. As a side note, this doesn't work exactly with the `pcod` data because of the unevenly spaced years. One could create a new time column, like below, but this would not preserve the same interpretation across folds. 
+
+```{r}
+# create a new variable that is 1-9, and has no missing years
+pcod$yearn <- as.numeric(as.factor(pcod$year))
+```
+
+Instead, we'll generate simulated data, 
+
+```{r}
+
+set.seed(123)
+
+# example based on documentation in ?sdmTMB_simulate
+predictor_dat <- data.frame(
+  X = runif(2000), Y = runif(2000),
+  a1 = rnorm(2000), year = rep(1:10, each = 200)
+)
+mesh <- make_mesh(predictor_dat, 
+                  xy_cols = c("X", "Y"), 
+                  cutoff = 0.1)
+
+sim_dat <- sdmTMB_simulate(
+  formula = ~ 1 + a1,
+  data = predictor_dat,
+  time = "year",
+  mesh = mesh,
+  family = gaussian(),
+  range = 0.5,
+  sigma_E = 0.1,
+  phi = 0.1,
+  sigma_O = 0.2,
+  seed = 42,
+  B = c(0.2, -0.4) # B0 = intercept, B1 = a1 slope
+)
+
+est_mesh <- make_mesh(sim_dat, 
+                      xy_cols = c("X","Y"), 
+                      cutoff=0.16)
+
+m_lfocv <- sdmTMB_cv(
+  observed ~ s(year, k = 3),
+  data = sim_dat,
+  mesh = est_mesh,
+  lfo = TRUE, # do LFOCV
+  lfo_forecast = 2, # number of time steps to forecast
+  lfo_validations = 4, # number of time steps to validate
+  spatiotemporal = "off",
+  time = "year" # must be specified
+)
+```
+=======
+>>>>>>> Stashed changes
+
+We can do LFOCV, using 3 parameters to `sdmTMB()` that control the type of cross validation. First, we enable LFOCV by setting `lfo = TRUE`. Second, we have to decide how many years of data to hold back as test or validation data (`lfo_validations`) and how many time steps ahead to forecast (`lfo_forecast`). Our dataset has 9 time steps, and we will begin with an example that uses 
+`lfo_forecast=1` and `lfo_validations=3`. This means that the cross validation will: 
+- Fit data to time steps 1 to 6, predict and validate step 7.
+- Fit data to time steps 1 to 7, predict and validate step 8.
+- Fit data to time steps 1 to 8, predict and validate step 9.
+
+```{r, eval=FALSE, include=FALSE}
+m_lfocv <- sdmTMB_cv(
+  present ~ s(year, k = 3),
+  data = pcod,
+  mesh = mesh,
+  lfo = TRUE, # do LFOCV
+  lfo_forecast = 1, # number of time steps to forecast
+  lfo_validations = 3, # number of time steps to validate
+  family = binomial(),
+  spatiotemporal = "off",
+  time = "nyear" # must be specified
+)
+```
+
+We can inspect how the folds are assigned with 
+
+```{r}
+example_data <- m_lfocv$models[[1]]$data
+table(example_data$cv_fold, example_data$year)
+```
+
+Next, we will change the `lfo_forecast` parameter to 2. This changes the structure so that we forecast 2 time steps ahead:
+- Fit data to time steps 1 to 5, predict and validate step 7.
+- Fit data to time steps 1 to 6, predict and validate step 8.
+- Fit data to time steps 1 to 7, predict and validate step 9.
 
 ```{r, eval=FALSE, include=FALSE}
 m_lfocv <- sdmTMB_cv(
@@ -192,10 +306,30 @@ m_lfocv <- sdmTMB_cv(
   spatiotemporal = "off",
   time = "year" # must be specified
 )
+```
 
-# See how the LFOCV folds were assigned:
-example_data <- m_lfocv$models[[2]]$data
+Again, we can examine the fold assignment. Note that we still have 4 folds, but for the sake of bookkeeping they're no longer labeled "1, 2, 3, 4" like above, but now are "1, 3, 4, 5":
+
+```{r}
+example_data <- m_lfocv$models[[1]]$data
 table(example_data$cv_fold, example_data$year)
+```
+
+We can also construct a similar model manually to make sure this is giving the approriate results. We will build a model using data through the 6th time step to predict time step 8. We use the `weights` argument here to turn off the contribution of data in time steps 8 and 9, using the same mesh as the full model above.
+
+```{r}
+yrs <- sort(unique(pcod$year))
+lfocv_validate <- sdmTMB(
+  present ~ s(year, k = 3),
+  data = pcod,
+  mesh = mesh,
+  family = binomial(),
+  spatiotemporal = "off",
+  time = "year", # must be specified
+  weights = ifelse(pcod$year %in% yrs[1:6], 1, 0)
+)
+
+cor(fitted(lfocv_validate), fitted(m_lfocv$models[[2]]))
 ```
 
 # Comparing two or more models


### PR DESCRIPTION
There was a problem with indexing created by a as.numeric() call, after removing that, LFOCV works forecasting > 1 time step ahead

- I also noticed in Readme that we hadn't put random slopes in -- added now