### PR TITLE
Add catch for missing RE columns

### DIFF
--- a/R/predict.R
+++ b/R/predict.R
@@ -445,6 +445,22 @@ predict.sdmTMB <- function(object, newdata = NULL,
 
     if (!"mgcv" %in% names(object)) object[["mgcv"]] <- FALSE
 
+    # This next ~ 10 lines fills in random effect columns that are missing in newdata
+    # extract all random effect names across all model components
+    RE_names_all <- unique(unlist(lapply(object$split_formula, function(x) x$barnames)))
+    # if re_form_iid is ~0 or NA, exclude them and just set NA
+    pop_pred_iid <- (!is.null(re_form_iid) && ((re_form_iid == ~0) || identical(re_form_iid, NA)))
+    # if we the re_form_iid is ~0 or NA
+    if (!pop_pred_iid) {
+      # loop over all names, finding names not in newdata. Add a column of NAs and add a new warning
+      for (re in RE_names_all) {
+        if (!re %in% names(newdata)) {
+          newdata[[re]] <- NA
+          cli_warn(sprintf("Column `%s` missing from `newdata`. Setting to `NA`.", re))
+        }
+      }
+    }
+
     # FIXME check if random slopes and intercepts are the same in both linear predictors?
     # parse random intercept/slope sparse model matrices on new data:
     Zt_list <- list()

--- a/tests/testthat/test-random-effects.R
+++ b/tests/testthat/test-random-effects.R
@@ -266,6 +266,14 @@ test_that("Model with random intercepts fits appropriately.", {
   m <- sdmTMB(data = s, formula = observed ~ 1 + (1 | g), spatial = "off")
   nd <- data.frame(g = factor(c(1, 2, 3, 800)), observed=1)
   expect_error(predict(m, newdata = nd), regexp = "Extra")
+
+  # predicting with missing factors works with the right re_form_iid
+  m <- sdmTMB(data = s, formula = observed ~ 1 + (1 | g), spatial = "off")
+  nd <- s[, !names(s) %in% "g", drop = FALSE]
+  p1 <- predict(m, newdata = nd, re_form_iid = ~0)
+  p2 <- predict(m, newdata = nd, re_form_iid = NA)
+  # and this fails when not correct
+  expect_error(predict(m, newdata = nd), regexp = "variable lengths differ")
 })
 
 test_that("Random intercepts and cross validation play nicely", {


### PR DESCRIPTION
If re_form_iid is 0 or NA, fills in columns in the newdata df that might be missing. Also included some new tests 