### PR TITLE
Fix LFOCV for lfo_forecast > 1

### DIFF
--- a/R/cross-val.R
+++ b/R/cross-val.R
@@ -175,7 +175,7 @@ ll_sdmTMB <- function(object, withheld_y, withheld_mu) {
 #' m_cv$models[[1]]
 #' m_cv$max_gradients
 #'
-#' \donttest{
+#'
 #' # Create mesh each fold:
 #' m_cv2 <- sdmTMB_cv(
 #'   density ~ 0 + depth_scaled + depth_scaled2,
@@ -190,24 +190,24 @@ ll_sdmTMB <- function(object, withheld_y, withheld_mu) {
 #'   family = tweedie(link = "log"),
 #'   fold_ids = rep(seq(1, 3), nrow(pcod))[seq(1, nrow(pcod))]
 #' )
-#
-# # LFOCV:
-# m_lfocv <- sdmTMB_cv(
-#   present ~ s(year, k = 4),
-#   data = pcod,
-#   mesh = mesh,
-#   lfo = TRUE,
-#   lfo_forecast = 2,
-#   lfo_validations = 3,
-#   family = binomial(),
-#   spatiotemporal = "off",
-#   time = "year" # must be specified
-# )
-#
-# # See how the LFOCV folds were assigned:
-# example_data <- m_lfocv$models[[1]]$data
-# table(example_data$cv_fold, example_data$year)
-#' }
+#'
+#' # LFOCV:
+#' m_lfocv <- sdmTMB_cv(
+#'   present ~ s(year, k = 4),
+#'   data = pcod,
+#'   mesh = mesh,
+#'   lfo = TRUE,
+#'   lfo_forecast = 2,
+#'   lfo_validations = 3,
+#'   family = binomial(),
+#'   spatiotemporal = "off",
+#'   time = "year" # must be specified
+#' )
+#'
+#' # See how the LFOCV folds were assigned:
+#' example_data <- m_lfocv$models[[1]]$data
+#' table(example_data$cv_fold, example_data$year)
+#'
 sdmTMB_cv <- function(
     formula, data, mesh_args, mesh = NULL, time = NULL,
     k_folds = 8, fold_ids = NULL,
@@ -244,11 +244,10 @@ sdmTMB_cv <- function(
       # Create lfo_validations + 1 folds, ordered sequentially
       data$cv_fold <- 1
       t_validate <- sort(unique(data[[time]]), decreasing = TRUE)
-      for (t in seq(1, lfo_validations)) {
+      for (t in seq(1, lfo_validations+lfo_forecast)) {
         # fold id increasing order + forecast
         data$cv_fold[data[[time]] == t_validate[t]] <- lfo_validations - t + 1 + lfo_forecast
       }
-      data$cv_fold <- as.numeric(as.factor(data$cv_fold))
     } else {
       dd <- lapply(split(data, data[[time]]), function(x) {
         x$cv_fold <- sample(rep(seq(1L, k_folds), nrow(x)), size = nrow(x))

--- a/man/sdmTMB_cv.Rd
+++ b/man/sdmTMB_cv.Rd
@@ -146,7 +146,7 @@ head(m_cv$data)
 m_cv$models[[1]]
 m_cv$max_gradients
 
-\donttest{
+
 # Create mesh each fold:
 m_cv2 <- sdmTMB_cv(
   density ~ 0 + depth_scaled + depth_scaled2,
@@ -161,5 +161,22 @@ m_cv3 <- sdmTMB_cv(
   family = tweedie(link = "log"),
   fold_ids = rep(seq(1, 3), nrow(pcod))[seq(1, nrow(pcod))]
 )
-}
+
+# LFOCV:
+m_lfocv <- sdmTMB_cv(
+  present ~ s(year, k = 4),
+  data = pcod,
+  mesh = mesh,
+  lfo = TRUE,
+  lfo_forecast = 2,
+  lfo_validations = 3,
+  family = binomial(),
+  spatiotemporal = "off",
+  time = "year" # must be specified
+)
+
+# See how the LFOCV folds were assigned:
+example_data <- m_lfocv$models[[1]]$data
+table(example_data$cv_fold, example_data$year)
+
 }


### PR DESCRIPTION
While attempting to perform leave-future-out cross-validation using the most up-to-date package version, I noticed that I got the error below whenever I set lfo_forecast to any value greater than 1. 
```
Warning: Caught tibble_error_assign_incompatible_size. Canceling all iterations ...
Error in `$<-`(`*tmp*`, "sdm_orig_id", value = 1:0) : 
  Assigned data `seq(1L, nrow(newdata))` must be compatible with existing data.
✖ Existing data has 0 rows.
✖ Assigned data has 2 rows.
ℹ Only vectors of size 1 are recycled.
Caused by error in `vectbl_recycle_rhs_rows()`:
! Can't recycle input of size 2 to size 0.
```
I decided to look into the source code and I think I found the source of the error, which I hope to have now fixed in my fork, as the LFOCV example in the sdmTMB_cv documentation file works for me now.

To explain what I changed, suppose I have 5 years, set lfo_validations = 2, and lfo_forecast =2. Previously, the fold IDs would have been 1 1 1 2 3 when they should be 1 1 2 3 4, because only years 1 and 2 (fold IDs are 1) should be used to validate year 4 (fold ID 3). Similarly, years 1, 2, and 3 (fold IDs are 1 and 2) should be used to validate year 5 (fold ID 4).

