### PR TITLE
Add residuals for truncated negative binomial families

### DIFF
--- a/tests/testthat/test-5-residuals.R
+++ b/tests/testthat/test-5-residuals.R
@@ -59,7 +59,6 @@ test_that("randomized quantile residuals work,", {
     data = d, mesh = mesh
   )
   check_resids(fit)
-  check_resids(fit)
   check_resids_dharma(fit)
 
   d <- sim_dat(lognormal())
@@ -165,7 +164,7 @@ test_that("randomized quantile residuals work,", {
     data = d, mesh = mesh,
     spatial = "off", spatiotemporal = "off"
   )
-  expect_error(residuals(fit, type = "mle-mvn"), regexp = "truncated_nbinom2")
+  check_resids(fit)
   check_resids_dharma(fit)
 
   d <- sim_dat(truncated_nbinom1())
@@ -175,8 +174,7 @@ test_that("randomized quantile residuals work,", {
     data = d, mesh = mesh,
     spatial = "off", spatiotemporal = "off"
   )
-
-  expect_error(residuals(fit, type = "mle-mvn"), regexp = "truncated_nbinom1")
+  check_resids(fit)
   check_resids_dharma(fit)
 
   d <- sim_dat(gengamma())


### PR DESCRIPTION
I noticed that the residuals function (and functions that depend on it) did not have a method for the truncated negative binomial distributions, including the delta distributions. I've written a few functions to implement this method, and they appear to work well in the tests I've done. I read the discussion in issue [350](https://github.com/pbs-assess/sdmTMB/issues/350), and found that it was easier to use the "untruncated" predictions when calculating the randomized quantile residuals. I hope that this decision is satisfactory; it does not appear to cause any obvious problems with residual plots or the Shapiro-Wilk test at least.