### PR TITLE
Add write permissions to pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,6 +14,8 @@ name: pkgdown
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}


### PR DESCRIPTION
Fix 403 Forbidden error when deploying to gh-pages branch.
GitHub Actions now requires explicit permissions for GITHUB_TOKEN
to push to branches.