### PR TITLE
fixes se_natural grab in index.R

### DIFF
--- a/R/index.R
+++ b/R/index.R
@@ -435,7 +435,7 @@ get_generic <- function(obj, value_name, bias_correct = FALSE, level = 0.95,
   # also grab natural space SE:
   if ("link_total" %in% value_name) {
     .total <- ssr[row.names(ssr) %in% "total", , drop = FALSE]
-    d$se_natural <- as.numeric(.total[,1])
+    d$se_natural <- as.numeric(.total[,2])
   }
 
   time_include <- NULL


### PR DESCRIPTION
Extraction of natural space Std Error in index.R was pulling the estimate of 'total' rather than the estimated standard error. (i.e. was referencing column 1 of the sdreport rather than column 2)

This commit changes the column number referenced.

(bug encountered by @CataRoman)